### PR TITLE
Added javac source and target versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ version := "0.1.1"
 
 scalaVersion := "2.10.3"
 
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+
 publishTo := Some(Resolver.file("file", new File(Path.userHome.absolutePath + "/.m2/repository")))
 
 parallelExecution in Test := false


### PR DESCRIPTION
To ensure that a compatible with JVM 7 bytecode is produced.
Current version of the library is built against Java 8:
http://search.maven.org/remotecontent?filepath=com/github/michaelpisula/akka-persistence-inmemory_2.10/0.1.1/akka-persistence-inmemory_2.10-0.1.1.jar

>  javap -verbose akka.persistence.journal.inmemory.InMemoryJournal | grep "major"
>   major version: 52

Which cause errors on JVM 7:

java.lang.UnsupportedClassVersionError: akka/persistence/journal/inmemory/InMemoryJournal : Unsupported major.minor version 52.0

It would be great to use akka-journal-inmemory with JVM 7 as Java 8 is not widely used yet and I believe most of the production Scala-Akka code is ran against JVM 7.
