### PR TITLE
Set up cross-building for Scala 2.10 and 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ version := "0.2.0"
 
 scalaVersion := "2.11.1"
 
+crossScalaVersions := Seq("2.10.4", "2.11.1")
+
 javacOptions in (Compile) ++= Seq("-source", "1.7")
 
 javacOptions in (Compile, compile) ++= Seq("-target", "1.7")


### PR DESCRIPTION
It would be great to have you library compiled for both 2.10 and 2.11.
I have set up cross-building by this guide: http://www.scala-sbt.org/0.13.5/docs/Detailed-Topics/Publishing.html
To activate a task for all the supported Scala version one need to prefix it with the plus sign "+":

\+ test
+ publish
+ makePom

I have checked out generated POM-files and they look valid. Tests also pass for all the versions.
